### PR TITLE
Refactored setup script with pyenv support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased changes] - 2019-11-20
+## [Unreleased changes] - 2019-11-23
 
 ### Added
 
@@ -36,6 +36,14 @@
 [Rust]: https://www.rust-lang.org/
 [markosamuli.rust]: https://github.com/markosamuli/ansible-rust
 
+### Fixed
+
+* Use `bash` executable instead of `sh` with Ansible on WSL environments to
+  get around Windows directory white spaces on the PATH. Fixes issues with
+  `zzet.rbenv` role no longer using bash for executing shell commands.
+* Fix `update-roles.py` script not working if using master as version in
+  `requirements.yml` file.
+
 ### Changed
 
 #### Ansible
@@ -47,11 +55,13 @@
 
 #### Setup script
 
-* Support for installing Ansible in a local virtualenv from PyPI
+* Rework on the setup script for improved Ansible installation when using
+  pyenv or virtualenv or calling Ansible with any non-system paths.
+* Support for installing Ansible in a local virtualenv from PyPI.
 * Allow setting the default Ansible version with `MACHINE_ANSIBLE_VERSION`
-  environment variable
-* Support for uninstalling existing Ansible installations
-* Added new long command line options in the setup script
+  environment variable.
+* Added support for uninstalling existing Ansible installations.
+* Added new long command line options in the setup script.
 
 #### Default installation options
 
@@ -134,18 +144,39 @@ symbolic links to `/usr/local/bin`. These will be removed automatically.
 [Python 2.7.17]: https://www.python.org/downloads/release/python-2717/
 [Python 3.7.5]: https://www.python.org/downloads/release/python-375/
 
+#### Makefile
+
+* Added Makefile with tasks for common playbooks.
+* Self-documented Makefile and `make help` command.
+* Added `setup` command for running `setup` script with the default options.
+* Removed `setup-ansible` and `setup-ansible-pypi` Makefile commands.
+* Added `install-ansible` Makefile command  that doesn't enable or disable PyPI
+  and doesn't reinstall existing Ansible installations.
+* Playbook short commands in Makefile will automatically install missing Ansible
+  roles.
+* Added `linuxbrew` Makefile command.
+* Renamed `roles` Makefile command to  `install-roles` and removed `-f` argument.
+* Renamed `update` Makefile command to  `update-roles`.
+* Added `clean-roles` Makefile command for running `clean-roles.py` script.
+* Added `latest-roles` Makefile command to update, clean and install required
+  Ansible roles to their latest versions.
+
+#### Travis
+
+* Fail fast on build errors
+* Run builds with Ansible 2.7, 2.8 and 2.9
+* Do not test manually installing PyPI
+
 #### Development improvements
 
-* Makefile with tasks for common playbooks
-* Self-documented Makefile and 'make help' command
-* Travis: Fail fast on build errors
-* Travis: Run builds with Ansible 2.7, 2.8 and 2.9
-* Travis: Do not test manually installing PyPI
-* GitHub Actions: Added new pre-commit workflow
+* Added new pre-commit workflow in GitHub Actions
 * Format Python code with [yapf] pre-commit hook
 * Validate shell scripts with [shellcheck] and improve coding style
 * Format shell scripts with [shfmt]
 * Setup virtualenv with pyenv for local development
+* Added `clean-roles.py` script for removing outdated Ansible roles.
+* Move development requirements from `requirements.txt` into a separate
+  `requirements.dev.txt` file to avoid installing those during normal usage.
 
 [yapf]: https://github.com/google/yapf
 [shellcheck]: https://github.com/koalaman/shellcheck

--- a/Makefile
+++ b/Makefile
@@ -134,6 +134,10 @@ docker:  ## install Docker
 gcloud: playbooks/roles/markosamuli.gcloud  ## install Google Cloud SDK
 	@./setup -q -t gcloud
 
+.PHONY: linuxbrew
+linuxbrew: playbooks/roles/markosamuli.linuxbrew  ## install Homebrew on Linux
+	@./setup -q -t linuxbrew
+
 .PHONY: golang
 golang: playbooks/roles/markosamuli.golang  ## install Go programming language
 	@./setup -q -t golang

--- a/Makefile
+++ b/Makefile
@@ -90,10 +90,6 @@ setup-ansible-pypi:  ## setup Ansible from PyPI without roles or running playboo
 		--print-versions \
 		--verbose
 
-.PHONY: update
-update:  ## update Ansible roles in the requirements.yml file
-	@./scripts/update-roles.py
-
 .PHONY: lint
 lint: pre-commit  ## lint source code
 
@@ -111,9 +107,20 @@ endif
 travis-lint: setup-pre-commit  ## lint .travis.yml file
 	@pre-commit run -a travis-lint -v
 
-.PHONY: roles
-roles:  ## install and update Ansible roles
-	@./setup -n -f
+.PHONY: install-roles
+install-roles:  ## install Ansible roles
+	@./setup -n
+
+.PHONY: clean-roles
+clean-roles: setup-requirements  ## remove outdated Ansible roles
+	@./scripts/clean-roles.py
+
+.PHONY: update-roles
+update-roles: setup-requirements  ## update Ansible roles in the requirements.yml file
+	@./scripts/update-roles.py
+
+.PHONY: latest-roles
+latest-roles: update-roles clean-roles install-roles  # update Ansible roles and install new versions
 
 .PHONY: aws
 aws:  ## install AWS tools

--- a/Makefile
+++ b/Makefile
@@ -116,44 +116,47 @@ roles:  ## install and update Ansible roles
 	@./setup -n -f
 
 .PHONY: aws
-aws: ## install AWS tools
+aws:  ## install AWS tools
 	@./setup -q -t aws
-
-.PHONY: tools
-tools: ## install tools
-	@./setup -q -t tools
-
-.PHONY: golang
-golang:  ## install Go programming language
-	@./setup -q -t golang
-
-.PHONY: python
-python:  ## install Python with pyenv
-	@./setup -q -t python,pyenv
-
-.PHONY: ruby
-ruby:  # install Ruby with rbenv
-	@./setup -q -t ruby,rbenv
-
-.PHONY: node
-node:  ## install Node.js with NVM
-	@./setup -q -t node,nvm
-
-.PHONY: terraform
-terraform:  ## install Terraform
-	@./setup -q -t terraform
-
-.PHONY: gcloud
-gcloud:  ## install Google Cloud SDK
-	@./setup -q -t gcloud
 
 .PHONY: docker
 docker:  ## install Docker
 	@./setup -q -t docker
 
+.PHONY: gcloud
+gcloud: playbooks/roles/markosamuli.gcloud  ## install Google Cloud SDK
+	@./setup -q -t gcloud
+
+.PHONY: golang
+golang: playbooks/roles/markosamuli.golang  ## install Go programming language
+	@./setup -q -t golang
+
+.PHONY: node
+node: playbooks/roles/markosamuli.nvm  ## install Node.js with NVM
+	@./setup -q -t node,nvm
+
+.PHONY: python
+python: playbooks/roles/markosamuli.pyenv  ## install Python with pyenv
+	@./setup -q -t python,pyenv
+
+.PHONY: ruby
+ruby: playbooks/roles/zzet.rbenv  # install Ruby with rbenv
+	@./setup -q -t ruby,rbenv
+
 .PHONY: rust
 rust: playbooks/roles/markosamuli.rust  ## install Rust
 	@./setup -q -t rust
+
+.PHONY: terraform
+terraform: playbooks/roles/markosamuli.terraform  ## install Terraform
+	@./setup -q -t terraform
+
+.PHONY: tools
+tools:  ## install tools
+	@./setup -q -t tools
+
+playbooks/roles/zzet.rbenv:
+	@./setup -n
 
 playbooks/roles/markosamuli.%:
 	@./setup -n

--- a/Makefile
+++ b/Makefile
@@ -147,6 +147,10 @@ node: playbooks/roles/markosamuli.nvm  ## install Node.js with NVM
 python: playbooks/roles/markosamuli.pyenv  ## install Python with pyenv
 	@./setup -q -t python,pyenv
 
+.PHONY: permissions
+permissions:  ## fix permissions in user home directory
+	@USER_HOME_FIX_PERMISSIONS=true ./setup -q -t permissions
+
 .PHONY: ruby
 ruby: playbooks/roles/zzet.rbenv  # install Ruby with rbenv
 	@./setup -q -t ruby,rbenv
@@ -164,14 +168,10 @@ tools:  ## install tools
 	@./setup -q -t tools
 
 playbooks/roles/zzet.rbenv:
-	@./setup -n
+	@./setup --no-run-playbook
 
 playbooks/roles/markosamuli.%:
-	@./setup -n
-
-.PHONY: permissions
-permissions:  ## fix permissions in user home directory
-	@USER_HOME_FIX_PERMISSIONS=true ./setup -q -t permissions
+	@./setup --no-run-playbook
 
 PRE_COMMIT_HOOKS = .git/hooks/pre-commit
 PRE_PUSH_HOOKS = .git/hooks/pre-push

--- a/README.md
+++ b/README.md
@@ -524,16 +524,22 @@ backup copies of them before running the script.
 The following external Ansible roles are installed and used. See
 [requirements.yml] file for the installed versions.
 
-To install roles and forcibly update any existing ones:
+To install roles:
 
 ```bash
-make roles
+make install-roles
 ```
 
 To update roles to the latest release versions:
 
 ```bash
-make update
+make update-roles
+```
+
+To remove any outdated roles:
+
+```bash
+make clean-roles
 ```
 
 | Role | Build status |

--- a/README.md
+++ b/README.md
@@ -25,36 +25,6 @@ See [markosamuli/macos-machine] for my macOS setup.
 [Ansible]: https://www.ansible.com/
 [markosamuli/macos-machine]: https://github.com/markosamuli/macos-machine
 
-## Ansible version
-
-The setup script will install Ansible using APT from [Ansible PPAs] if
-the `ansible` command is not found on your system.
-
-If an acceptable Ansible APT package installation candidate can't be found
-the setup script will try to install Ansible with PIP in a local virtuelenv.
-
-If `virtuelenv` can't be found the setup script the setup will fail.
-
-You can define `MACHINE_ANSIBLE_VERSION` environment variable to change
-the installed version.
-
-Example to use Ansible 2.8:
-
-```bash
-export MACHINE_ANSIBLE_VERSION=2.8
-```
-
-| Version | PPA |
-|---------|-----|
-| `2.7` | [ansible/ansible-2.7] |
-| `2.8` (default) | [ansible/ansible-2.8] |
-| `2.9` | [ansible/ansible-2.9] |
-
-[Ansible PPAs]: https://launchpad.net/~ansible
-[ansible/ansible-2.7]: https://launchpad.net/~ansible/+archive/ubuntu/ansible-2.7
-[ansible/ansible-2.8]: https://launchpad.net/~ansible/+archive/ubuntu/ansible-2.8
-[ansible/ansible-2.9]: https://launchpad.net/~ansible/+archive/ubuntu/ansible-2.9
-
 ### Ubuntu
 
 This setup has been tested on the [Ubuntu] [16.04 LTS (Xenial Xerus)]
@@ -139,6 +109,80 @@ The `setup` script will detect if this file exists and passes it to the
 Ansible Playbook with `--extra-vars`.
 
 [machine.yaml]: machine.yaml
+
+## Ansible
+
+The setup script will try to install Ansible
+
+### Ansible version
+
+Ansible version 2.8 is installed by default.
+
+You can define `MACHINE_ANSIBLE_VERSION` environment variable to change
+the installed version.
+
+Example to use Ansible 2.9 instead of Ansible 2.8:
+
+```bash
+export MACHINE_ANSIBLE_VERSION=2.9
+```
+
+### Force Ansible reinstall
+
+To remove existing Ansible versions and force installation of Ansible, you
+can use the `--reinstall-ansible` argument, for example:
+
+```bash
+./setup --reinstall-ansible
+```
+
+### Installing Ansible with APT
+
+The setup script will install Ansible using APT from [Ansible PPAs] if
+the `ansible` command is not found on your system.
+
+| Version | PPA |
+|---------|-----|
+| `2.7` | [ansible/ansible-2.7] |
+| `2.8` (default) | [ansible/ansible-2.8] |
+| `2.9` | [ansible/ansible-2.9] |
+
+[Ansible PPAs]: https://launchpad.net/~ansible
+[ansible/ansible-2.7]: https://launchpad.net/~ansible/+archive/ubuntu/ansible-2.7
+[ansible/ansible-2.8]: https://launchpad.net/~ansible/+archive/ubuntu/ansible-2.8
+[ansible/ansible-2.9]: https://launchpad.net/~ansible/+archive/ubuntu/ansible-2.9
+
+### Installing Ansible from PyPI into virtualenv
+
+If an acceptable Ansible APT package installation candidate can't be found
+the setup script will try to install Ansible with [pip] in a local virtuelenv.
+
+If [virtuelenv] can't be found the setup script the setup will fail.
+
+You can disable installation from PyPI with `--disable-ansible-pypi` argument,
+for example:
+
+```bash
+./setup --disable-ansible-pypi
+```
+
+[pip]: https://pypi.org/project/pip/
+[virtuelenv]: https://virtualenv.pypa.io/en/latest/
+
+### Installing Ansible from PyPI into pyenv environment
+
+If the user has set up a local development environment with [pyenv] and this is
+defined in a `.python-version` file in the repository root, the setup script
+will install Ansible into this environment.
+
+Same as with the local virtualenv, you can disable installation from PyPI
+with `--disable-ansible-pypi` argument, for example:
+
+```bash
+./setup --disable-ansible-pypi
+```
+
+[pyenv]: https://github.com/pyenv/pyenv
 
 ## Software installed by the playbooks
 
@@ -570,12 +614,6 @@ make clean-roles
 [requirements.yml]: requirements.yml
 
 ## Development
-
-Fix ansible-lint installation issues:
-
-```bash
-pip install virtualenv==16.3.0
-```
 
 Install [pre-commit] hooks:
 

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,0 +1,2 @@
+pre-commit==1.20.0
+virtualenv==16.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,1 @@
-pre-commit==1.20.0
 PyYAML<6,>=5.1
-virtualenv==16.3.0

--- a/scripts/clean-roles.py
+++ b/scripts/clean-roles.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+
+import yaml
+import os
+import shutil
+import logging
+
+META_INSTALL = os.path.join('meta', '.galaxy_install_info')
+
+
+def list_required_roles():
+    """Return Ansible roles from the requirements.yml file"""
+    roles = []
+    role_file = 'requirements.yml'
+    with open(role_file, 'r') as f:
+        required_roles = yaml.safe_load(f.read())
+        for role in required_roles:
+            roles.append(role)
+    return sorted(roles, key=lambda role: role['name'])
+
+
+def list_installed_roles(roles_path):
+    """List installed roles and get version from .galaxy_install_info file"""
+
+    roles = []
+
+    path_files = os.listdir(roles_path)
+    for path_file in path_files:
+        path = os.path.join(roles_path, path_file)
+
+        install_info = None
+        info_path = os.path.join(path, META_INSTALL)
+        if os.path.isfile(info_path):
+            with open(info_path, 'r') as f:
+                install_info = yaml.safe_load(f)
+
+        version = None
+        if install_info:
+            version = install_info['version']
+
+        git = False
+        git_path = os.path.join(path, '.git')
+        if os.path.exists(git_path):
+            git = True
+
+        roles.append({
+            'name': os.path.basename(path),
+            'version': version,
+            'path': path,
+            'git': git
+        })
+
+    return sorted(roles, key=lambda role: role['name'])
+
+
+def main():
+    """Remove any outdates Ansible roles"""
+
+    required_roles = list_required_roles()
+    installed_roles = list_installed_roles("playbooks/roles")
+
+    for required_role in required_roles:
+
+        installed = False
+        for installed_role in installed_roles:
+
+            if required_role['name'] != installed_role['name']:
+                continue
+
+            installed = True
+
+            role_path = installed_role['path']
+
+            if installed_role['git']:
+                logging.debug('role %s in %s is a Git repository',
+                              installed_role['name'], role_path)
+                continue
+
+            if not installed_role['version']:
+                logging.debug(
+                    'role %s installed %s != required %s'.
+                    installed_role['name'], '(unknown version)',
+                    required_role['version'])
+                continue
+
+            if required_role['version'] == installed_role['version']:
+                logging.debug('role %s installed %s', installed_role['name'],
+                              installed_role['version'])
+                continue
+
+            logging.info('role %s installed %s != required %s',
+                         installed_role['name'], installed_role['version'],
+                         required_role['version'])
+
+            if os.path.isdir(role_path):
+                logging.info("remove role in %s", role_path)
+                shutil.rmtree(role_path)
+
+        if not installed:
+            logging.debug('role %s not installed', required_role['name'])
+
+
+if __name__ == '__main__':
+    main()

--- a/setup
+++ b/setup
@@ -25,7 +25,6 @@ is_wsl=""          # Windows Subsystem for Linux
 
 # macOS specific setup options
 install_homebrew=1 # Install Homebrew
-ansible_homebrew=1 # Force use of Ansible from Homebrew
 
 # Environment configuration
 deploy_env="local"
@@ -36,25 +35,33 @@ local_vars_file="machine.yaml"
 # Ansible playbook options
 ansible_playbook="playbooks/main.yml"
 ansible_roles="playbooks/roles"
-ansible_roles_opts=""
 ansible_tags=""
 ansible_skip_tags=""
 ansible_verbose=0
 ansible_become=0
 
-# Install Ansible from PyPI
-ansible_pypi="${MACHINE_ANSIBLE_PYPI:-false}"
+# Ansible pyenv version / environment name
+ansible_pyenv=""
 
-# Ansible virtualenv
+# Ansible virtualenv path
 ansible_virtualenv="${DIR}/.venv"
 
 # Ansible version test
 required_ansible_version="2.7"
 
-# Ansible PPA to use
+# Ansible version to install
 ansible_version="${MACHINE_ANSIBLE_VERSION:-2.8}"
+
+# Ansible PPA to use
 ansible_ppa="ansible/ansible-${ansible_version}"
 ansible_ppa_key_id="93C4A3FD7BB9C367"
+
+# Ansible installation options
+ansible_pypi_enabled="${MACHINE_ANSIBLE_PYPI}"
+ansible_apt_enabled="${MACHINE_ANSIBLE_APT}"
+ansible_homebrew_enabled="${MACHINE_ANSIBLE_HOMEBREW}"
+ansible_virtualenv_enabled="${MACHINE_ANSIBLE_VIRTUALENV}"
+ansible_pyenv_enabled="${MACHINE_ANSIBLE_PYENV}"
 
 # Print error into STDERR
 error() {
@@ -106,25 +113,39 @@ END_OF_OPTIONS
 
 # Get Ansible version
 get_ansible_version() {
-    "$(ansible_bin_prefix)ansible" \
-        --version |
-        grep "^ansible" |
-        awk '{ print $2 }'
+    local version
+    version=$(ansible_exec ansible --version 2>/dev/null)
+    if [ -n "$version" ]; then
+        echo "${version}" | grep "^ansible" | awk '{ print $2 }'
+    fi
+}
+
+# Check installed Ansible version meets the requirements
+check_installed_ansible_version() {
+    if is_true "${print_versions}"; then
+        local installed_version
+        installed_version=$(get_ansible_version)
+        echo "*** Ansible version ${installed_version} installed"
+    fi
+    if ! is_required_ansible_version_installed ${required_ansible_version}; then
+        error "Ansible ${required_ansible_version} required"
+        exit 1
+    fi
 }
 
 # Check we're not using broken Ansible versions
 check_broken_ansible_versions() {
     local installed_version
     installed_version=$(get_ansible_version)
-    echo "*** Check that we're not using Ansible v2.8.6"
+    # Check that we're not using Ansible v2.8.6
     if [ "${installed_version}" == "2.8.6" ]; then
         error "Ansible v2.8.6 is not supported, try upgrading to Ansible v2.8.7"
-        exit 1
+        return 1
     fi
 }
 
-# Check Ansible version
-check_ansible_version() {
+# Check Ansible version matches the required version
+is_required_ansible_version_installed() {
     local IFS=.
     # shellcheck disable=SC2206
     local required=($1)
@@ -149,18 +170,18 @@ check_ansible_version() {
 
 # Install dependencies on Linux
 install_linux_dependencies() {
-    if [ "${install_ansible}" == "1" ]; then
+    if is_true "${install_ansible}"; then
         install_ansible
     fi
 }
 
 # Install dependencies on macOS
 install_macos_dependencies() {
-    if [ "${install_homebrew}" == "1" ]; then
+    if is_true "${install_homebrew}"; then
         install_xcode_cli
         install_homebrew
     fi
-    if [ "${install_ansible}" == "1" ]; then
+    if is_true "${install_ansible}"; then
         install_ansible
     fi
 }
@@ -170,11 +191,10 @@ install_xcode_cli() {
     if command -v gcc >/dev/null; then
         return 0
     fi
-    local errmsg="Failed to install Xcode Command Line Tools"
     echo "*** Installing Xcode Command Line Tools..."
     xcode-select --install ||
         {
-            error "${errmsg}"
+            error "Failed to install Xcode Command Line Tools"
             exit 1
         }
 }
@@ -186,20 +206,19 @@ install_homebrew() {
     fi
     local url="https://raw.githubusercontent.com"
     url="${url}/Homebrew/install/master/install"
-    local errmsg="Failed to install Homebrew"
     echo "*** Installing Homebrew..."
     ruby -e "$(curl -fsSL ${url})" ||
         {
-            error "${errmsg}"
+            error "Failed to install Homebrew"
             exit 1
         }
 }
 
 # Install Ansible
 install_ansible() {
-    if [ "${is_macos}" == "1" ]; then
+    if is_true "${is_macos}"; then
         install_ansible_on_macos
-    elif [ "${is_linux}" == "1" ]; then
+    elif is_true "${is_linux}"; then
         install_ansible_on_linux
     else
         error "Your system is not supported"
@@ -207,68 +226,137 @@ install_ansible() {
     fi
 }
 
+# Is Ansible installed on the PATH or in the custom location
+is_ansible_installed() {
+    # Check Homebrew installation
+    if is_ansible_homebrew_enabled; then
+        # Fail if Ansible formula is not found
+        if [ "$(brew --prefix ansible)" == "" ]; then
+            return 1
+        fi
+    fi
+    # Fail if 'ansible --version' doesn't work
+    if [ -z "$(ansible_exec ansible --version 2>/dev/null)" ]; then
+        return 1
+    fi
+}
+
 # Install Ansible on Linux
 install_ansible_on_linux() {
-    if command -v ansible >/dev/null; then
+
+    if is_ansible_installed; then
         return 0
     fi
-    if [ "${is_ubuntu}" == "1" ]; then
-        if [ "${ansible_pypi}" != "true" ]; then
-            install_ansible_on_ubuntu && return 0
+
+    echo "*** Install Ansible on Linux..."
+
+    # Enable APT installation as the default option if neither APT or
+    # PyPI installation option have been set or if PyPI has been disabled.
+    if [ -z "${ansible_apt_enabled}" ]; then
+        if [ -z "${ansible_pypi_enabled}" ]; then
+            ansible_apt_enabled=true
+        elif is_ansible_pypi_disabled; then
+            ansible_apt_enabled=true
         fi
-        if [ "${ansible_pypi}" != "never" ]; then
-            install_ansible_with_pip && return 0
-        fi
-        error "Failed to install Ansible"
-        exit 1
-    elif [ "${is_pengwin}" == "1" ]; then
-        if [ "${ansible_pypi}" != "true" ]; then
-            install_ansible_on_debian && return 0
-        fi
-        if [ "${ansible_pypi}" != "never" ]; then
-            install_ansible_with_pip && return 0
-        fi
-        error "Failed to install Ansible"
-        exit 1
-    else
-        error "Your system is not supported"
-        exit 1
     fi
+
+    # Install Ansible with APT
+    if is_ansible_apt_enabled; then
+        if is_true "${is_ubuntu}"; then
+            if install_ansible_with_apt_on_ubuntu; then
+                return 0
+            fi
+        elif is_true "${is_pengwin}"; then
+            if install_ansible_with_apt_on_debian; then
+                return 0
+            fi
+        else
+            error "Your system is not supported"
+            exit 1
+        fi
+    fi
+
+    # Fallback to PyPI installation unless explicitly disabled
+    if [ -z "${ansible_pypi_enabled}" ]; then
+        echo "*** Enabled PyPI installation"
+        ansible_pypi_enabled=true
+    fi
+
+    # Install Ansible from PyPI package
+    if is_ansible_pypi_enabled; then
+        if install_ansible_with_pip; then
+            return 0
+        fi
+    fi
+
+    error "Failed to install Ansible"
+    exit 1
 }
 
 # Install Ansible on macOS
 install_ansible_on_macos() {
-    if command -v ansible >/dev/null; then
-        # If we don't require Ansible from Homebrew
-        if [ "${ansible_homebrew}" == "0" ]; then
-            return 0
+
+    if is_ansible_installed; then
+        return 0
+    fi
+
+    echo "Install Ansible on macOS..."
+
+    # Enable Homebrew installation as the default option if neither Homebrew or
+    # PyPI installation option have been set or if PyPI has been disabled.
+    if [ -z "${ansible_homebrew_enabled}" ]; then
+        if [ -z "${ansible_pypi_enabled}" ]; then
+            ansible_homebrew_enabled=true
+        elif is_ansible_pypi_disabled; then
+            ansible_homebrew_enabled=true
         fi
-        # Check if Ansible is installed with Homebrew
-        if [ "$(brew --prefix ansible)" != "" ]; then
+    fi
+
+    # Install Ansible from Homebrew
+    if is_ansible_homebrew_enabled; then
+        if is_true "${is_macos}"; then
+            if install_ansible_with_homebrew; then
+                return 0
+            fi
+        else
+            error "Your system is not supported"
+            exit 1
+        fi
+    fi
+
+    # Fallback to PyPI installation unless explicitly disabled
+    if [ -z "${ansible_pypi_enabled}" ]; then
+        echo "*** Enabled PyPI installation"
+        ansible_pypi_enabled=true
+    fi
+
+    # Install Ansible from PyPI package
+    if is_ansible_pypi_enabled; then
+        if install_ansible_with_pip; then
             return 0
         fi
     fi
-    install_ansible_with_homebrew
+
+    error "Failed to install Ansible"
+    exit 1
 }
 
 # Install Ansible with Homebrew
 install_ansible_with_homebrew() {
-    local errmsg="Failed to install Ansible"
     echo "*** Installing Ansible with Homebrew..."
     brew install ansible ||
         {
-            error "${errmsg}"
+            error "Failed to install Ansible with Homebrew"
             exit 1
         }
 }
 
 # Uninstall Ansible from Homebrew
 uninstall_ansible_with_homebrew() {
-    local errmsg="Failed to uninstall Ansible"
     echo "*** Uninstalling Ansible with Homebrew..."
     brew uninstall ansible ||
         {
-            error "${errmsg}"
+            error "Failed to uninstall Ansible with Homebrew"
             exit 1
         }
 
@@ -286,76 +374,179 @@ apt_install_candidate() {
 
 # Instal Ansible with PIP
 install_ansible_with_pip() {
-    local ansible_pypi_version
-
-    if ! command -v pip >/dev/null; then
-        error "pip not found"
-        return 1
-    fi
+    local package_version
 
     if [ "${ansible_version}" == "2.7" ]; then
-        ansible_pypi_version="<2.8"
+        package_version="<2.8"
     elif [ "${ansible_version}" == "2.8" ]; then
-        ansible_pypi_version="!=2.8.6,<2.9"
+        package_version="!=2.8.6,<2.9"
     elif [ "${ansible_version}" == "2.9" ]; then
-        ansible_pypi_version="<2.10"
+        package_version="<2.10"
     else
         error "Unsupported Ansible version ${ansible_version}"
         return 1
     fi
 
-    if ! command -v virtualenv >/dev/null; then
-        error "Python virtuelenv not found"
+    if is_true "${ansible_pyenv_enabled}"; then
+        if [ -n "${ansible_pyenv}" ]; then
+            install_ansible_in_pyenv \
+                "${package_version}" \
+                "${ansible_pyenv}" || return 1
+            return 0
+        fi
+    fi
+
+    if is_true "${ansible_virtualenv_enabled}"; then
+        if [ -n "${ansible_virtualenv}" ]; then
+            install_ansible_in_virtualenv \
+                "${package_version}" \
+                "${ansible_virtualenv}" || return 1
+            return 0
+        fi
+    fi
+
+    error "Couldn't find local pyenv or virtualenv environments"
+    return 1
+}
+
+# Install Ansible in the given pyenv version
+install_ansible_in_pyenv() {
+    local package_version="$1"
+    local pyenv_version="$2"
+
+    if ! command -v pyenv >/dev/null; then
+        error "pyenv not found"
         return 1
     fi
 
-    if [ ! -d "${ansible_virtualenv}" ]; then
-        virtualenv "${ansible_virtualenv}" || {
-            error "Failed to create virtualenv in ${ansible_virtualenv}"
-            return 1
-        }
-    fi
+    echo "*** Install Ansible PyPI (ansible${package_version}) in ${pyenv_version}"
 
-    echo "*** Activate virtualenv in ${ansible_virtualenv}"
-    # shellcheck disable=SC1090
-    source "${ansible_virtualenv}/bin/activate"
-
-    pip install "ansible${ansible_pypi_version}" || {
-        error "Failed to install Ansible"
+    pyenv_exec "${pyenv_version}" \
+        pip install "ansible${package_version}" || {
+        error "Failed to install Ansible in ${pyenv_version}"
         return 1
     }
 
-    echo "*** Ansible ${ansible_version} installed"
-    ansible_pypi=true
+    PYENV_VERSION="${pyenv_version}" pyenv rehash
+
+    echo "*** Ansible ${ansible_version} installed in ${pyenv_version}"
+    ansible_pypi_enabled=true
 }
 
-install_software_properties_common() {
-    local installed
-    installed=$(dpkg -s software-properties-common 2>/dev/null | grep 'Status' | grep installed)
-    if [ -z "${installed}" ]; then
-        echo "*** Install software-properties-common..."
-        sudo apt-get install -y software-properties-common
+# Check if virtualenv command is installed
+is_virtualenv_installed() {
+    if ! command -v virtualenv >/dev/null; then
+        return 1
+    fi
+    if [ -z "$(virtualenv --version 2>/dev/null)" ]; then
+        return 1
+    fi
+}
+
+# Create virtualenv in given directory if it doesn't already exist
+create_virtualenv() {
+    local virtualenv_path="$2"
+
+    if [ ! -d "${virtualenv_path}" ]; then
+
+        if ! is_virtualenv_installed; then
+            error "Python virtuelenv command not found"
+            return 1
+        fi
+
+        virtualenv "${virtualenv_path}" || {
+            error "Failed to create virtualenv in ${virtualenv_path}"
+            return 1
+        }
+    fi
+}
+
+# Install Ansible in a virtualenv
+install_ansible_in_virtualenv() {
+    local package_version="$1"
+    local virtualenv_path="$2"
+
+    create_virtualenv "${virtualenv_path}" || return 1
+
+    echo "*** Install Ansible PyPI (ansible${package_version}) in ${virtualenv_path}"
+
+    virtualenv_exec "${virtualenv_path}" \
+        pip install "ansible${package_version}" || {
+        error "Failed to install Ansible in ${virtualenv_path}"
+        return 1
+    }
+
+    echo "*** Ansible ${ansible_version} installed into ${virtualenv_path}"
+    ansible_pypi_enabled=true
+}
+
+# Install missing APT package
+install_apt_package() {
+    local package="$1"
+    if ! is_apt_package_installed "${package}"; then
+        echo "*** Install ${package}..."
+        sudo apt-get install -y "${package}" || {
+            error "Failed to install ${package}"
+            return 1
+        }
+    fi
+}
+
+# Remove APT package if installed
+remove_apt_package() {
+    local package="$1"
+    if is_apt_package_installed "${package}"; then
+        echo "*** Remove ${package} APT package..."
+        sudo apt-get remove -y "${package}" || {
+            error "Failed to remove ${package}"
+            return 1
+        }
     fi
 }
 
 # Remove Ansible installations
-remove_ansible() {
+remove_ansible_installations() {
 
+    # Skip if not enabled
+    if ! is_true "${remove_ansible}"; then
+        return
+    fi
+
+    # Remove any local virtuelenv directories
     remove_ansible_virtualenv
 
-    if [ "${is_macos}" == "1" ]; then
-        uninstall_ansible_with_homebrew
-    elif [ "${is_linux}" == "1" ]; then
-        if [ "${is_ubuntu}" == "1" ]; then
-            remove_ansible_apt
-            remove_ansible_ppa_sources_list
-        elif [ "${is_pengwin}" == "1" ]; then
-            remove_ansible_apt
-            remove_ansible_ppa_sources_list
+    # Find local pyenv version
+    local pyenv_version
+    if [ -n "${ansible_pyenv}" ]; then
+        pyenv_version="${ansible_pyenv}"
+    elif [ -e ".python-version" ]; then
+        # Check .python-version file even if PyPi install is disabled
+        pyenv_version=$(cat .python-version)
+    fi
+
+    # Uninstall Ansible package from the pyenv environment
+    if [ -n "${pyenv_version}" ]; then
+        local pyenv_installed
+        pyenv_installed=$(pyenv_exec "${pyenv_version}" pip freeze | grep "^ansible==")
+        if [ -n "${pyenv_installed}" ]; then
+            echo "*** Uninstall ansible PyPI from pyenv version ${pyenv_version}"
+            pyenv_exec "${pyenv_version}" pip uninstall -y ansible
         fi
+    fi
+
+    # Remove Homebrew installations on macOS
+    if is_true "${is_macos}"; then
+        uninstall_ansible_with_homebrew
+    fi
+
+    # Remove APT installations on Ubuntu and Debian-based systems
+    if is_true "${is_ubuntu}" || is_true "${is_pengwin}"; then
+        remove_apt_package "ansible"
+        remove_ansible_apt_sources_list
     fi
 }
 
+# Install Ansible PPA on Ubuntu
 install_ansible_ppa_on_ubuntu() {
 
     # Do not add PPA if it already exists
@@ -366,7 +557,7 @@ install_ansible_ppa_on_ubuntu() {
         fi
     fi
 
-    install_software_properties_common
+    install_apt_package "software-properties-common"
 
     echo "*** Add ${ansible_ppa} PPA repository..."
     sudo apt-add-repository -y "ppa:${ansible_ppa}"
@@ -377,7 +568,8 @@ install_ansible_ppa_on_ubuntu() {
     sudo apt-get update
 }
 
-remove_ansible_ppa_sources_list() {
+# Remove all Ansible sources list files
+remove_ansible_apt_sources_list() {
     local update_apt_cache
     for apt_list in /etc/apt/sources.list.d/ansible*.list; do
         if [ -e "${apt_list}" ]; then
@@ -395,8 +587,15 @@ remove_ansible_ppa_sources_list() {
     fi
 }
 
-# Remove virtualenv when using OS package installation
+# Remove local virtualenv when using OS installation method
 remove_ansible_virtualenv() {
+    # Deactivate current virtualenv before deleting it
+    if [ -n "${VIRTUAL_ENV}" ]; then
+        if [ "$(type -f deactivate)" == "function" ]; then
+            deactivate
+        fi
+    fi
+    ## Remove virtualenv directory
     if [ -d "${ansible_virtualenv}" ]; then
         echo "*** Removing virtualenv in '${ansible_virtualenv}'"
         rm -rf "${ansible_virtualenv}"
@@ -404,7 +603,7 @@ remove_ansible_virtualenv() {
 }
 
 # Install Ansible with APT on Ubuntu
-install_ansible_on_ubuntu() {
+install_ansible_with_apt_on_ubuntu() {
 
     install_ansible_ppa_on_ubuntu
 
@@ -418,11 +617,14 @@ install_ansible_on_ubuntu() {
     remove_ansible_virtualenv
 }
 
+# Install Ansible PPA on Debian
 install_ansible_ppa_on_debian() {
+
     local deb_url="http://ppa.launchpad.net/${ansible_ppa}/ubuntu"
     local apt_list="/etc/apt/sources.list.d/ansible.list"
 
     if [ -e "${apt_list}" ]; then
+        # Do nothing if the correct PPA URL exists in the APT sources list file
         if grep -q "^deb ${deb_url}" "${apt_list}"; then
             return 0
         fi
@@ -440,7 +642,7 @@ install_ansible_ppa_on_debian() {
 }
 
 # Install Ansible with APT on Debian
-install_ansible_on_debian() {
+install_ansible_with_apt_on_debian() {
 
     install_ansible_ppa_on_debian
 
@@ -466,12 +668,21 @@ install_ansible_apt() {
     fi
 
     echo "*** Installing Ansible ${version}..."
-    sudo apt-get install -y "ansible=${version}*"
+    sudo apt-get install -y "ansible=${version}*" || {
+        error "Failed to install ansible=${version}*"
+        return 1
+    }
 }
 
-# Remove Ansible APT package
-remove_ansible_apt() {
-    sudo apt-get remove -y "ansible"
+# Check if an APT package has been installed
+is_apt_package_installed() {
+    local package="$1"
+    status=$(dpkg-query --show --showformat='${db:Status-Status}\n' "${package}")
+    if [ "${status}" == "installed" ]; then
+        return 0
+    else
+        return 1
+    fi
 }
 
 # Add Ansible PPA signing key
@@ -489,26 +700,47 @@ remove_ansible_ppa_key() {
 
 # Install Ansible roles
 install_ansible_roles() {
-    local errmsg="Failed to install Ansible roles"
+
+    # Skip if install_roles is not enabled
+    if ! is_true "${install_roles}"; then
+        return
+    fi
+
+    local ansible_roles_opts=""
+
+    if is_true "${install_roles_force}"; then
+        ansible_roles_opts="${ansible_roles_opts} --force"
+    fi
+
     echo "*** Installing Ansible roles..."
-    "$(ansible_bin_prefix)ansible-galaxy" install \
+    # shellcheck disable=SC2086
+    ansible_exec ansible-galaxy install \
         -r requirements.yml \
         -p ${ansible_roles} \
         ${ansible_roles_opts} ||
         {
-            error "${errmsg}"
+            error "Failed to install Ansible roles"
             exit 1
         }
 }
 
 # Update Ansible roles
 update_ansible_roles() {
-    local errmsg="Failed to update Ansible roles"
+
+    # Skip if update_roles is not enabled
+    if ! is_true "${update_roles}"; then
+        return
+    fi
+
     echo "*** Installing Python requirements..."
-    pip install -r requirements.txt
+    pip install -r requirements.txt || {
+        error "Failed to install required packages"
+        exit 1
+    }
+
     echo "*** Updating Ansible roles..."
     ./scripts/update-roles.py || {
-        error "${errmsg}"
+        error "Failed to update Ansible roles"
         exit 1
     }
 }
@@ -568,12 +800,80 @@ detect_pengwin() {
     fi
 }
 
-# Ansible binary prefix
-ansible_bin_prefix() {
-    if [ "${is_macos}" == "1" ]; then
-        if [ "${ansible_homebrew}" == "1" ]; then
-            echo "$(brew --prefix ansible)/bin/"
+# Execute command with pyenv version
+pyenv_exec() {
+    local args=("$@")
+    # The first argument is the pyenv version
+    local pyenv_version="${args[0]}"
+    # shellcheck disable=SC2068
+    PYENV_VERSION="${pyenv_version}" pyenv exec "${args[@]:1}"
+}
+
+# Execute command in virtualenv
+virtualenv_exec() {
+    local args=("$@")
+    # The first argument is the virtualenv path
+    local virtualenv_path="${args[0]}"
+    if [ -d "${virtualenv_path}" ]; then
+        error "${virtualenv_path} not found"
+        exit 1
+    fi
+    # shellcheck disable=SC2068
+    PATH="${virtualenv_path}/bin:$PATH" ${args[@]:1}
+}
+
+# Execute Ansible commands in the correct environment
+ansible_exec() {
+    # When double quoted, "$@" expands to separate strings - "$1" "$2" "$n".
+    local args=("$@")
+
+    # Custom path to Ansible binaries
+    local ansible_path
+
+    # Get Homebrew Ansible installation prefix
+    if is_ansible_homebrew_enabled; then
+        local prefix
+        prefix="$(brew --prefix ansible)"
+        if [ -n "${prefix}" ] && [ -d "${prefix}/bin" ]; then
+            ansible_path="${prefix}/bin"
         fi
+    fi
+
+    # Get pyenv version
+    local pyenv_version
+    if is_true "${ansible_pyenv_enabled}"; then
+        if [ -n "${ansible_pyenv}" ]; then
+            pyenv_version="${ansible_pyenv}"
+        fi
+    fi
+
+    # Get virtualenv path
+    local virtualenv_path
+    if is_true "${ansible_virtualenv_enabled}"; then
+        if [ -n "${ansible_virtualenv}" ] && [ -d "${ansible_virtualenv}" ]; then
+            virtualenv_path="${ansible_virtualenv}"
+        fi
+    fi
+
+    if [ -n "${ansible_path}" ]; then
+        # Execute with the custom path
+        # echo "*** Execute with custom path ${ansible_path}" >&2
+        # shellcheck disable=SC2068
+        PATH="${ansible_path}:$PATH" ${args[@]}
+    elif [ -n "${pyenv_version}" ]; then
+        # Execute in the local pyenv
+        # echo "*** Execute with pyenv ${pyenv_version}" >&2
+        # shellcheck disable=SC2068
+        pyenv_exec "${pyenv_version}" "${args[@]}"
+    elif [ -n "${virtualenv_path}" ]; then
+        # Execute in the local virtualenv
+        # echo "*** Execute with virtualenv ${virtualenv_path}" >&2
+        # shellcheck disable=SC2068
+        virtualenv_exec "${virtualenv_path}" "${args[@]}"
+    else
+        # echo "*** Execute with system PATH" >&2
+        # shellcheck disable=SC2068
+        ${args[@]}
     fi
 }
 
@@ -586,7 +886,7 @@ run_ansible_playbook() {
     fi
 
     # shellcheck disable=SC2046
-    "$(ansible_bin_prefix)ansible-playbook" "${ansible_playbook}" \
+    ansible_exec ansible-playbook "${ansible_playbook}" \
         $(ansible_inventory) \
         $(run_ansible_playbook_opts)
 }
@@ -600,7 +900,7 @@ run_ansible_playbook_opts() {
         ansible_opts+=("--extra-vars @${local_vars_file}")
     fi
 
-    if [ "${ansible_verbose}" == "1" ]; then
+    if is_true "${ansible_verbose}"; then
         ansible_opts+=("-v")
     fi
 
@@ -615,8 +915,8 @@ run_ansible_playbook_opts() {
     # Variables to pass to ansible-playbook
     local ansible_vars=()
 
-    if [ "${is_linux}" == "1" ]; then
-        if [ "${is_wsl}" == "1" ]; then
+    if is_true "${is_linux}"; then
+        if is_true "${is_wsl}"; then
             ansible_vars+=("\"is_wsl\":true")
         else
             ansible_vars+=("\"is_wsl\":false")
@@ -633,7 +933,7 @@ run_ansible_playbook_opts() {
         ansible_opts+=("-e ${extra_vars}")
     fi
 
-    if [ "${ansible_become}" == "1" ]; then
+    if is_true "${ansible_become}"; then
         sudo true || {
             error "sudo failed"
             exit 1
@@ -647,7 +947,7 @@ run_ansible_playbook_opts() {
 # Check Ansible playbook syntax
 check_ansible_playbook_syntax() {
     # shellcheck disable=SC2046
-    "$(ansible_bin_prefix)ansible-playbook" ${ansible_playbook} \
+    ansible_exec ansible-playbook ${ansible_playbook} \
         $(ansible_inventory) \
         --syntax-check
 }
@@ -670,7 +970,7 @@ ansible_inventory() {
 # List tags available in Ansible playbooks
 ansible_playbook_list_tags() {
     # shellcheck disable=SC2046
-    "$(ansible_bin_prefix)ansible-playbook" ${ansible_playbook} \
+    ansible_exec ansible-playbook ${ansible_playbook} \
         $(ansible_inventory) \
         --list-tags
 }
@@ -678,86 +978,184 @@ ansible_playbook_list_tags() {
 # Setup dependencies
 setup_dependencies() {
 
-    if [ "${is_macos}" == "1" ]; then
+    if is_true "${is_macos}"; then
         install_macos_dependencies
-    elif [ "${is_linux}" == "1" ]; then
+    elif is_true "${is_linux}"; then
         install_linux_dependencies
     else
         error "Your system is not supported"
         exit 1
     fi
 
-    local ansible_err="Ansible not found"
-    if [ "$(ansible_bin_prefix)" == "" ]; then
-        if ! command -v ansible >/dev/null; then
-            error "${ansible_err}"
-            exit 1
-        fi
-    else
-        "$(ansible_bin_prefix)ansible" --version >/dev/null ||
-            {
-                error "${ansible_err}"
-                exit 1
-            }
+    if ! is_ansible_installed; then
+        error "Ansible not found"
+        exit 1
     fi
+}
 
+# Configure options on macOS
+configure_macos() {
+    # Do not use sudo on macOS
+    ansible_become=0
+    # Disable APT installation source on macOS
+    ansible_apt_enabled=false
+}
+
+# Configure options on Linux
+configure_linux() {
+    # Enable sudo on Linux
+    ansible_become=1
+    # Disable Homebrew installation source on Linux
+    ansible_homebrew_enabled=false
+    # Do not install Homebrew on Linux
+    install_homebrew=0
+    # Use bash on WSL to avoid issues with spaces on the PATH
+    if is_true "${is_wsl}"; then
+        ansible_executable=$(command -v /bin/bash 2>/dev/null)
+    fi
 }
 
 # Configure options
 configure_options() {
-    if [ "${is_macos}" == "1" ]; then
-        ansible_become=0
-    elif [ "${is_linux}" == "1" ]; then
-        ansible_become=1
-        ansible_homebrew=0
-        install_homebrew=0
-        if [ "${is_wsl}" == "1" ]; then
-            ansible_executable=$(command -v /bin/bash 2>/dev/null)
-        fi
+    if is_true "${is_macos}"; then
+        configure_macos
+    elif is_true "${is_linux}"; then
+        configure_linux
+    else
+        error "Your system is not supported"
+        exit 1
     fi
 }
 
-# Configure Ansible PATH
-configure_ansible_path() {
-    # Skip virtualenv and PATH config if using Homebrew
-    if [ "${ansible_homebrew}" == "1" ]; then
+# Is Ansible Homebrew installation enabled
+is_ansible_homebrew_enabled() {
+    # Homebrew installation is only supported on macOS
+    is_true "${is_macos}" || return 1
+    is_true "${ansible_homebrew_enabled}" || return 1
+}
+
+# Is Ansible PyPI installation enabled?
+is_ansible_pypi_enabled() {
+    is_true "${ansible_pypi_enabled}" || return 1
+}
+
+# Is Ansible PyPI installation disabled?
+is_ansible_pypi_disabled() {
+    is_false "${ansible_pypi_enabled}" || return 1
+}
+
+# Is Ansible APT installation enabled?
+is_ansible_apt_enabled() {
+    # Homebrew installation is not supported on macOS
+    is_true "${is_macos}" && return 1
+    is_true "${ansible_apt_enabled}" || return 1
+}
+
+# Is variable set to a true value?
+is_true() {
+    local value="$1"
+    if [ -z "${value}" ]; then
+        return 1
+    fi
+    if [ "${value}" == "true" ]; then
+        return 0
+    fi
+    if [ "${value}" == "1" ]; then
+        return 0
+    fi
+    return 1
+}
+
+# Is variable set to a false value?
+is_false() {
+    local value="$1"
+    if [ -z "${value}" ]; then
+        return 1
+    fi
+    if [ "${value}" == "false" ]; then
+        return 0
+    fi
+    if [ "${value}" == "0" ]; then
+        return 0
+    fi
+    return 1
+}
+
+# Configure Ansible PyPI installation options
+configure_pypi() {
+
+    # Skip virtualenv if using Homebrew
+    if is_ansible_homebrew_enabled; then
         return 0
     fi
 
-    # Activate local virtualenv if found
-    if [ -d "${ansible_virtualenv}" ]; then
-        echo "*** Activate virtualenv in ${ansible_virtualenv}"
-        # shellcheck disable=SC1090
-        source "${ansible_virtualenv}/bin/activate"
-        ansible_pypi=1
+    # Skip virtualenv configuration if we've disabled PyPI installation
+    if is_ansible_pypi_disabled; then
         return 0
     fi
 
-    # Use Ansible from ~/.local if found
-    local local_bin_path
-    if [ -e "$HOME/.local/bin/ansible" ]; then
-        echo "*** Ansible found in ~/.local/bin"
-        local_bin_path=$(echo "$PATH" | grep "$HOME/\.local/bin")
-        if [ -z "${local_bin_path}" ]; then
-            echo "*** Adding ~/.local/bin to PATH"
-            PATH="$PATH:$HOME/.local/bin"
-        fi
-        ansible_pypi=1
-        return 0
+    # Enable PyPI installation if local virtualenv is found
+    configure_virtualenv
+
+    # Enable PyPI installation if local pyenv is found
+    configure_pyenv
+}
+
+configure_virtualenv() {
+
+    # Check if virtualenv is installed
+    if ! command -v virtualenv >/dev/null; then
+        ansible_virtualenv_enabled=false
+        return 1
+    fi
+
+    # Do not configure if virtualenv is disabled
+    if is_false "${ansible_virtualenv_enabled}"; then
+        return 1
+    fi
+
+    # Install from PyPI if local virtualenv is found
+    if [ -n "${ansible_virtualenv}" ] && [ -d "${ansible_virtualenv}" ]; then
+        echo "*** Use virtualenv in ${ansible_virtualenv}"
+        ansible_pypi_enabled=true
+        ansible_virtualenv_enabled=true
+    fi
+}
+
+# Configure pyenv installation options
+configure_pyenv() {
+
+    # Check if pyenv is installed
+    if ! command -v pyenv >/dev/null; then
+        ansible_pyenv_enabled=false
+        return 1
+    fi
+
+    # Do not configure if pyenv is disabled
+    if is_false "${ansible_pyenv_enabled}"; then
+        return 1
+    fi
+
+    # Use local pyenv version if found
+    if [ -e ".python-version" ]; then
+        ansible_pypi_enabled=true
+        ansible_pyenv_enabled=true
+        ansible_pyenv="$(cat .python-version)"
+        echo "*** Use pyenv version ${ansible_pyenv}"
     fi
 }
 
 # Check for upgrades
 check_upgrades() {
-    if [ "${check_os_upgrades}" != "1" ]; then
+    if ! is_true "${check_os_upgrades}"; then
         return 0
     fi
-    if [ "${is_ubuntu}" == "1" ]; then
+    if is_true "${is_ubuntu}"; then
         check_dist_upgrades
-    elif [ "${is_pengwin}" == "1" ]; then
+    elif is_true "${is_pengwin}"; then
         check_dist_upgrades
         check_pengwin_upgrades
-    elif [ "${is_macos}" == "1" ]; then
+    elif is_true "${is_macos}"; then
         check_brew_upgrades
     fi
 }
@@ -803,6 +1201,13 @@ check_user() {
     fi
 }
 
+print_installed_versions() {
+    if is_true "${print_versions}"; then
+        python --version
+        ansible --version
+    fi
+}
+
 # Parse command line arguments
 POSITIONAL=()
 while [[ $# -gt 0 ]]; do
@@ -814,11 +1219,35 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         --enable-ansible-pypi)
-            ansible_pypi=true
+            ansible_pypi_enabled=true
             shift
             ;;
         --disable-ansible-pypi)
-            ansible_pypi=never
+            ansible_pypi_enabled=false
+            shift
+            ;;
+        --disable-ansible-pyenv)
+            ansible_pyenv_enabled=false
+            shift
+            ;;
+        --disable-ansible-virtualenv)
+            ansible_virtualenv_enabled=false
+            shift
+            ;;
+        --enable-ansible-apt)
+            ansible_apt_enabled=true
+            shift
+            ;;
+        --disable-ansible-apt)
+            ansible_apt_enabled=false
+            shift
+            ;;
+        --enable-ansible-homebrew)
+            ansible_homebrew_enabled=true
+            shift
+            ;;
+        --disable-ansible-homebrew)
+            ansible_homebrew_enabled=false
             shift
             ;;
         --install-ansible)
@@ -907,13 +1336,11 @@ detect_os
 # Configure options
 configure_options
 
-# Remove existing Ansible installations
-if [ "${remove_ansible}" == "1" ]; then
-    remove_ansible
-fi
+# Configure Ansible installation options if using PyPI and virtualenv
+configure_pypi
 
-# Configure Ansible path
-configure_ansible_path
+# Remove existing Ansible installations
+remove_ansible_installations
 
 # Setup dependencies
 setup_dependencies
@@ -924,30 +1351,22 @@ check_upgrades
 # Check current user is not root
 check_user
 
-if [ "${print_versions}" == "1" ]; then
-    python --version
-    ansible --version
-fi
+# Display installed versions
+print_installed_versions
 
-if ! check_ansible_version ${required_ansible_version}; then
-    error "Ansible ${required_ansible_version} required"
-    exit 1
-fi
+# Check installed Ansible version meets the requirements
+check_installed_ansible_version
 
+# Check we don't have broken versions installed
 check_broken_ansible_versions
 
-if [ "${update_roles}" == "1" ]; then
-    update_ansible_roles
-fi
+# Update Ansible role versions in requirements.yml
+update_ansible_roles
 
-if [ "${install_roles_force}" == "1" ]; then
-    ansible_roles_opts="${ansible_roles_opts} --force"
-fi
+# Install Ansile roles
+install_ansible_roles
 
-if [ "${install_roles}" == "1" ]; then
-    install_ansible_roles
-fi
-
+# Run a setup command
 if [ "${list_tags}" == "1" ]; then
     ansible_playbook_list_tags
 elif [ "${syntax_check}" == "1" ]; then

--- a/setup
+++ b/setup
@@ -579,6 +579,12 @@ ansible_bin_prefix() {
 
 # Run Ansible playbook
 run_ansible_playbook() {
+
+    if [ -n "${ansible_executable}" ]; then
+        echo "*** Use ${ansible_executable} as Ansible executable"
+        export ANSIBLE_EXECUTABLE="${ansible_executable}"
+    fi
+
     # shellcheck disable=SC2046
     "$(ansible_bin_prefix)ansible-playbook" "${ansible_playbook}" \
         $(ansible_inventory) \
@@ -705,6 +711,9 @@ configure_options() {
         ansible_become=1
         ansible_homebrew=0
         install_homebrew=0
+        if [ "${is_wsl}" == "1" ]; then
+            ansible_executable=$(command -v /bin/bash 2>/dev/null)
+        fi
     fi
 }
 


### PR DESCRIPTION
Setup script:

- Rework on the `setup` script for improved Ansible installation when using `pyenv` or `virtualenv` or calling Ansible with any non-system paths.
- Use `/bin/bash` executable instead of `/bin/sh` with Ansible on WSL environments to get around Windows directory white spaces on the `PATH`. Fixes issues with `zzet.rbenv` role no longer using `bash` for executing shell commands.

Role scripts:

- Added `clean-roles.py` script for removing outdated Ansible roles.
- Fix `update-roles.py` script not working if using `master` as version in `requirements.yml` file.

Makefile:

- Added `setup` command for running `setup` script with the default options.
- Removed `setup-ansible` and `setup-ansible-pypi` Makefile commands.
- Added `install-ansible` Makefile command  that doesn't enable or disable PyPI and doesn't reinstall existing Ansible installations.
- Playbook short commands in Makefile will automatically install missing Ansible roles.
- Added `linuxbrew` Makefile command.
- Renamed `roles` Makefile command to  `install-roles` and removed `-f` argument.
- Renamed `update` Makefile command to  `update-roles`.
- Added `clean-roles` Makefile command for running `clean-roles.py` script.
- Added `latest-roles` Makefile command to update, clean and install required Ansible roles to their latest versions.

Development environment:

- Move development requirements from `requirements.txt` into a separate `requirements.dev.txt` file to avoid installing those during normal usage.