### PR TITLE
feat: install Shellcheck from binary

### DIFF
--- a/playbooks/roles/shellcheck/defaults/main.yml
+++ b/playbooks/roles/shellcheck/defaults/main.yml
@@ -1,3 +1,1 @@
 ---
-# Default to snap
-shellcheck_snap: true

--- a/playbooks/roles/shellcheck/tasks/install_apt.yml
+++ b/playbooks/roles/shellcheck/tasks/install_apt.yml
@@ -1,0 +1,6 @@
+---
+- name: Install shellcheck via APT
+  become: true
+  package:
+    name: shellcheck
+    state: present

--- a/playbooks/roles/shellcheck/tasks/install_binary.yml
+++ b/playbooks/roles/shellcheck/tasks/install_binary.yml
@@ -1,0 +1,75 @@
+---
+- name: Remove Shellcheck installed using any package manager
+  become: true
+  package:
+    name: shellcheck
+    state: absent
+
+- name: Check for an existing Shellcheck installation
+  become: true
+  stat:
+    path: "{{ shellcheck_bin_path }}"
+  register: shellcheck_bin_st
+
+- name: Check installed Shellcheck version
+  shell: |
+    set -o pipefail
+    {{ shellcheck_bin_path }} --version | grep -o 'version: \([0-9]*\.[0-9]*\.[0-9]*\)' | sed 's/version: //'
+  register: shellcheck_bin_version
+  when:
+    - shellcheck_bin_st.stat.exists
+  changed_when: false
+
+- name: Install Shellcheck if binary is missing
+  set_fact:
+    shellcheck_bin_install: true
+  when:
+    - not shellcheck_bin_st.stat.exists
+
+- name: Install Shellcheck if version does not match
+  set_fact:
+    shellcheck_bin_install: true
+  when:
+    - shellcheck_bin_st.stat.exists
+    - shellcheck_bin_version is defined
+    - shellcheck_bin_version.stdout is version(shellcheck_version | regex_replace('^v(.*)$', '\\1'), '<')
+
+- name: Install Shellcheck from binary package
+  become: true
+  when: shellcheck_bin_install | default(false)
+  block:
+    - name: Shellcheck binary installation dependencies
+      apt:
+        name: xz-utils
+        state: present
+
+    - name: Create temporary directory
+      tempfile:
+        state: directory
+        suffix: shellcheck
+      register: shellcheck_temp
+
+    - name: Download Shellcheck binary package
+      get_url:
+        url: "{{ shellcheck_url }}"
+        dest: "{{ shellcheck_temp.path }}/{{ shellcheck_file }}"
+        checksum: "{{ shellcheck_checksum }}"
+        mode: "0644"
+
+    - name: Extract Shellcheck binary package
+      unarchive:
+        src: "{{ shellcheck_temp.path }}/{{ shellcheck_file }}"
+        dest: "{{ shellcheck_temp.path }}"
+        remote_src: yes
+        creates: "{{ shellcheck_temp.path }}/shellcheck-{{ shellcheck_version }}/shellcheck"
+        mode: "0755"
+
+    - name: Move Shellcheck installation
+      command: "mv {{ shellcheck_temp.path }}/shellcheck-{{ shellcheck_version }}/shellcheck {{ shellcheck_bin_path }}"
+      args:
+        creates: "{{ shellcheck_bin_path }}"
+
+    - name: Delete temporary directory
+      file:
+        path: "{{ shellcheck_temp.path }}"
+        state: absent

--- a/playbooks/roles/shellcheck/tasks/install_snap.yml
+++ b/playbooks/roles/shellcheck/tasks/install_snap.yml
@@ -1,0 +1,6 @@
+---
+- name: Install shellcheck from Snap Store
+  become: true
+  snap:
+    name: shellcheck
+    state: present

--- a/playbooks/roles/shellcheck/tasks/main.yml
+++ b/playbooks/roles/shellcheck/tasks/main.yml
@@ -1,20 +1,30 @@
 ---
-- name: Install shellcheck via APT on Debian
+- name: Load variables for the target system
+  include_vars: "{{ item }}"
+  with_first_found:
+    - "os/{{ ansible_distribution }}/{{ ansible_distribution_release }}.yml"
+    - "os/{{ ansible_distribution }}.yml"
+
+- name: Snap Store is not supported on WSL environments
   set_fact:
     shellcheck_snap: false
-  when: ansible_distribution == 'Debian'
+  when:
+    - is_wsl | bool
+    - shellcheck_snap | bool
 
-- name: Install shellcheck via APT on Ubuntu 20.04 LTS
-  set_fact:
-    shellcheck_snap: false
-  when: ansible_distribution == 'Ubuntu' and ansible_distribution_release == "focal"
+- name: Install shellcheck using APT
+  include_tasks: install_apt.yml
+  when:
+    - shellcheck_apt | bool
 
-- name: Install shellcheck (snap)
-  snap:
-    name: shellcheck
-  when: shellcheck_snap
+- name: Install shellcheck from Snap Store
+  include_tasks: install_snap.yml
+  when:
+    - shellcheck_snap | bool
+    - not shellcheck_apt | bool
 
-- name: Install shellcheck (apt)
-  package:
-    name: shellcheck
-  when: not shellcheck_snap
+- name: Install shellcheck from binary package
+  include_tasks: install_binary.yml
+  when:
+    - not shellcheck_snap | bool
+    - not shellcheck_apt | bool

--- a/playbooks/roles/shellcheck/vars/main.yml
+++ b/playbooks/roles/shellcheck/vars/main.yml
@@ -1,0 +1,9 @@
+---
+shellcheck_install_prefix: "/usr/local"
+shellcheck_bin_path: "{{ shellcheck_install_prefix }}/bin/shellcheck"
+
+shellcheck_version: "v0.7.1"
+shellcheck_repo: https://github.com/koalaman/shellcheck
+shellcheck_file: "shellcheck-{{ shellcheck_version }}.linux.x86_64.tar.xz"
+shellcheck_url: "{{ shellcheck_repo }}/releases/download/{{ shellcheck_version }}/{{ shellcheck_file }}"
+shellcheck_checksum: "sha256:64f17152d96d7ec261ad3086ed42d18232fcb65148b44571b564d688269d36c8"

--- a/playbooks/roles/shellcheck/vars/os/Debian.yml
+++ b/playbooks/roles/shellcheck/vars/os/Debian.yml
@@ -1,0 +1,3 @@
+---
+shellcheck_snap: false
+shellcheck_apt: false

--- a/playbooks/roles/shellcheck/vars/os/Debian/bullseye.yml
+++ b/playbooks/roles/shellcheck/vars/os/Debian/bullseye.yml
@@ -1,0 +1,3 @@
+---
+shellcheck_snap: false
+shellcheck_apt: true

--- a/playbooks/roles/shellcheck/vars/os/Ubuntu.yml
+++ b/playbooks/roles/shellcheck/vars/os/Ubuntu.yml
@@ -1,0 +1,3 @@
+---
+shellcheck_snap: true
+shellcheck_apt: false

--- a/playbooks/roles/shellcheck/vars/os/Ubuntu/focal.yml
+++ b/playbooks/roles/shellcheck/vars/os/Ubuntu/focal.yml
@@ -1,0 +1,3 @@
+---
+shellcheck_snap: false
+shellcheck_apt: true


### PR DESCRIPTION
Install Shellcheck from the binary package on any systems where the
latest version is not available using any package manager.